### PR TITLE
Session trait refactorings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 node_modules/
 dist/
 dist-sandbox/
-
+coverage/
 /lib
 
 # Compiled Java class files

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist/
 dist-sandbox/
 sample/
+coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Type `Traits` renamed more precisely to `SessionTraits` and moved to `types.ts` file
 - Type `TraitValue` renamed more precisely to `SessionTraitValue`
-- Method `sendSessionTraits` now returns a response typed `IdentifySessionResponse` with well-typed error 
+- Method `sendSessionTraits` now returns a response typed `IdentifySessionResponse` with well-typed error
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased](https://github.com/Smartesting/gravity-data-collector/compare/v2.2.0...main)
 
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Type `Traits` renamed more precisely to `SessionTraits` and moved to `types.ts` file
+- Type `TraitValue` renamed more precisely to `SessionTraitValue`
+- Method `sendSessionTraits` now returns a response typed `IdentifySessionResponse` with well-typed error 
+
 ### Deprecated
 
 ### Removed
@@ -20,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Stop tracking when receiving errors specified in [config.ts](./src/config.ts)
+
+- Prevent error in method `isKeyAllowedByKeyListeners`
 
 ## [2.2.0](https://github.com/Smartesting/gravity-data-collector/compare/v2.1.11...v2.2.0)
 

--- a/src/collector/CollectorWrapper.ts
+++ b/src/collector/CollectorWrapper.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { createSessionStartedUserAction } from '../user-action/createSessionStartedUserAction'
-import { CollectorOptions, SessionStartedUserAction, TraitValue } from '../types'
+import { CollectorOptions, SessionStartedUserAction, SessionTraitValue } from '../types'
 import UserActionHandler from '../user-action/UserActionHandler'
 import { debugUserActionSessionSender, defaultUserActionSessionSender } from '../user-action/userActionSessionSender'
 import SessionIdHandler from '../session-id-handler/SessionIdHandler'
@@ -80,7 +80,7 @@ class CollectorWrapper {
     this.trackingHandler.init(this.eventListenerHandler)
   }
 
-  identifySession(traitName: string, traitValue: TraitValue) {
+  identifySession(traitName: string, traitValue: SessionTraitValue) {
     if (this.trackingHandler.isTracking()) this.sessionTraitHandler.handle(traitName, traitValue)
   }
 

--- a/src/collector/GravityCollector.ts
+++ b/src/collector/GravityCollector.ts
@@ -1,5 +1,5 @@
 import CollectorWrapper from './CollectorWrapper'
-import { CollectorOptions, TraitValue } from '../types'
+import { CollectorOptions, SessionTraitValue } from '../types'
 import windowExists from '../utils/windowExists'
 import completeOptions from '../utils/completeOptions'
 import SessionStorageSessionIdHandler from '../session-id-handler/SessionStorageSessionIdHandler'
@@ -30,7 +30,7 @@ export default class GravityCollector {
     )
   }
 
-  static identifySession(traitName: string, traitValue: TraitValue) {
+  static identifySession(traitName: string, traitValue: SessionTraitValue) {
     const collectorWrapper = (window as any)._GravityCollector.collectorWrapper
     if (collectorWrapper === undefined) {
       throw new Error('Gravity Data Collector was not initialized : please call window.GravityCollector.init() before')

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -4,41 +4,56 @@ import {
   buildGravityTrackingPublishApiUrl,
   GRAVITY_SERVER_ADDRESS,
 } from '../gravityEndPoints'
+import { v4 as uuidv4 } from 'uuid'
+import { IdentifySessionError } from '../session-trait/sessionTraitSender'
 
 export const VALID_AUTH_KEY = 'VALID_AUTH_KEY'
+export const VALID_SESSION_ID = uuidv4()
+export const VALID_SOURCE = 'https://my-domain.com'
 export const DUMMY_AUTH_KEY_CAUSING_NETWORK_ERROR = 'DUMMY_AUTH_KEY_CAUSING_ERROR'
 
 export const handlers = [
   rest.post(buildGravityTrackingPublishApiUrl(':authKey', GRAVITY_SERVER_ADDRESS), async (req, res, ctx) => {
     const { authKey } = req.params
-    if (authKey === DUMMY_AUTH_KEY_CAUSING_NETWORK_ERROR) {
-      throw new Error('Network Error')
-    }
-    if (authKey !== VALID_AUTH_KEY) {
-      return await res(ctx.status(403), ctx.json({}))
-    }
+    if (authKey === DUMMY_AUTH_KEY_CAUSING_NETWORK_ERROR) throw new Error('Network Error')
+    if (authKey !== VALID_AUTH_KEY) return await res(ctx.status(403), ctx.json({}))
     const payload = await req.json()
     if (!Array.isArray(payload)) return await res(ctx.status(422), ctx.json({}))
-
     return await res(ctx.status(200), ctx.json({ error: null }))
   }),
 
   rest.post(
     buildGravityTrackingIdentifySessionApiUrl(':authKey', GRAVITY_SERVER_ADDRESS, ':sessionId'),
     async (req, res, ctx) => {
-      const { authKey } = req.params
-      if (authKey === DUMMY_AUTH_KEY_CAUSING_NETWORK_ERROR) {
-        throw new Error('Network Error')
+      const { authKey, sessionId } = req.params
+      if (authKey === DUMMY_AUTH_KEY_CAUSING_NETWORK_ERROR) throw new Error('Network Error')
+      if (sessionId !== VALID_SESSION_ID) {
+        return await res(ctx.status(403), ctx.json({ error: IdentifySessionError.accessDenied }))
+      }
+      const origin = req.headers.get('Origin')
+      if (origin !== null && getHostname(origin) !== VALID_SOURCE) {
+        return await res(ctx.status(403), ctx.json({ error: IdentifySessionError.incorrectSource }))
       }
       if (authKey !== VALID_AUTH_KEY) {
-        return await res(ctx.status(403), ctx.json({}))
+        return await res(ctx.status(404), ctx.json({ error: IdentifySessionError.noCollection }))
       }
       const payload = await req.json()
       for (const value of Object.values(payload)) {
-        if (Array.isArray(value) || typeof value === 'object') return await res(ctx.status(422), ctx.json({}))
+        const type = typeof value
+        if (!['string', 'boolean', 'number'].includes(type)) {
+          return await res(ctx.status(422), ctx.json({ error: IdentifySessionError.invalidField }))
+        }
+        if (type === 'string' && (value as string).length > 255) {
+          return await res(ctx.status(422), ctx.json({ error: IdentifySessionError.invalidField }))
+        }
       }
-
       return await res(ctx.status(200), ctx.json({ error: null }))
     },
   ),
 ]
+
+function getHostname(source: string) {
+  try {
+    return new URL(source).hostname
+  } catch (_) {}
+}

--- a/src/session-trait/SessionTraitHandler.ts
+++ b/src/session-trait/SessionTraitHandler.ts
@@ -1,15 +1,13 @@
-import { TraitValue } from '../types'
-
-export type Traits = Record<string, TraitValue>
+import { SessionTraits, SessionTraitValue } from '../types'
 
 export default class SessionTraitHandler {
-  private buffer: Traits = {}
+  private buffer: SessionTraits = {}
   private readonly timer?: NodeJS.Timer
 
   constructor(
     private readonly sessionId: string,
     private readonly requestInterval: number,
-    private readonly output: (sessionId: string, traits: Traits) => void,
+    private readonly output: (sessionId: string, traits: SessionTraits) => void,
   ) {
     if (requestInterval > 0) {
       this.timer = setInterval(() => {
@@ -18,7 +16,7 @@ export default class SessionTraitHandler {
     }
   }
 
-  handle(traitName: string, traitValue: TraitValue) {
+  handle(traitName: string, traitValue: SessionTraitValue) {
     this.buffer[traitName] = traitValue
     if (this.timer == null) {
       this.flush()

--- a/src/session-trait/sessionTraitSender.test.ts
+++ b/src/session-trait/sessionTraitSender.test.ts
@@ -1,56 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { DUMMY_AUTH_KEY_CAUSING_NETWORK_ERROR, VALID_AUTH_KEY } from '../mocks/handlers'
-import { waitFor } from '@testing-library/dom'
+import { VALID_AUTH_KEY, VALID_SESSION_ID } from '../mocks/handlers'
 import { nop } from '../utils/nop'
 import { buildGravityTrackingIdentifySessionApiUrl, GRAVITY_SERVER_ADDRESS } from '../gravityEndPoints'
-import { debugSessionTraitSender, defaultSessionTraitSender, sendSessionTraits } from './sessionTraitSender'
+import { debugSessionTraitSender, IdentifySessionError, sendSessionTraits } from './sessionTraitSender'
 
 describe('sessionTraitSender', () => {
-  describe('defaultSessionTraitSender', () => {
-    beforeEach(() => {
-      vi.restoreAllMocks()
-    })
-
-    const spySuccess = vi.fn()
-    const spyError = vi.fn()
-
-    it('sends session traits if valid auth key', async () => {
-      await defaultSessionTraitSender(
-        VALID_AUTH_KEY,
-        GRAVITY_SERVER_ADDRESS,
-        spySuccess,
-      )('123-abd', { connected: true })
-      await waitFor(() => {
-        expect(spySuccess).toHaveBeenCalledWith({ error: null })
-      })
-    })
-
-    it('catches error if invalid auth key', async () => {
-      await defaultSessionTraitSender(
-        'DUMMY_AUTH_KEY',
-        GRAVITY_SERVER_ADDRESS,
-        spySuccess,
-        spyError,
-      )('123-abd', { connected: true })
-      await waitFor(() => {
-        expect(spyError).toHaveBeenCalledWith(403)
-      })
-    })
-
-    it('catches any error', async () => {
-      await defaultSessionTraitSender(
-        DUMMY_AUTH_KEY_CAUSING_NETWORK_ERROR,
-        GRAVITY_SERVER_ADDRESS,
-        spySuccess,
-        spyError,
-      )('123-abd', { connected: true })
-      await waitFor(() => {
-        expect(spyError).toHaveBeenCalledOnce()
-        expect((spyError.mock.lastCall as any[])[0]).toMatch(/request to (.+?) failed, reason: Network Error/)
-      })
-    })
-  })
-
   describe('debugSessionTraitSender', () => {
     beforeEach(() => {
       vi.useFakeTimers()
@@ -74,7 +28,7 @@ describe('sessionTraitSender', () => {
 
   describe('sendSessionTraits', () => {
     it('sets the `Origin` header when a source is provided', async () => {
-      const fetch = vi.fn()
+      const fetch = mockFetch()
 
       await sendSessionTraits(
         VALID_AUTH_KEY,
@@ -101,7 +55,7 @@ describe('sessionTraitSender', () => {
     })
 
     it('does not set the `Origin` header when no source is provided', async () => {
-      const fetch = vi.fn()
+      const fetch = mockFetch()
 
       await sendSessionTraits(
         VALID_AUTH_KEY,
@@ -125,5 +79,100 @@ describe('sessionTraitSender', () => {
         },
       )
     })
+
+    describe('return a response typed IdentifySessionResponse', async () => {
+      const onSuccess: () => void = vi.fn()
+      const onError: (statusCode: number, error: IdentifySessionError) => void = vi.fn()
+
+      beforeEach(() => {
+        vi.clearAllMocks()
+      })
+
+      it('without error if succeeded', async () => {
+        expect(
+          await sendSessionTraits(
+            VALID_AUTH_KEY,
+            GRAVITY_SERVER_ADDRESS,
+            VALID_SESSION_ID,
+            { age: 23 },
+            null,
+            onSuccess,
+            onError,
+          ),
+        ).toEqual({ error: null })
+        expect(onSuccess).toHaveBeenCalled()
+        expect(onError).not.toHaveBeenCalled()
+      })
+
+      it('with accessDenied error if sessionId is incorrect', async () => {
+        expect(
+          await sendSessionTraits(
+            VALID_AUTH_KEY,
+            GRAVITY_SERVER_ADDRESS,
+            'notAccessibleSessionId',
+            { age: 23 },
+            null,
+            onSuccess,
+            onError,
+          ),
+        ).toEqual({ error: IdentifySessionError.accessDenied })
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(onError).toHaveBeenCalledWith(403, IdentifySessionError.accessDenied)
+      })
+
+      it('with noCollection error if authKey does not match a known session collection', async () => {
+        expect(
+          await sendSessionTraits(
+            'unknownAuthKey',
+            GRAVITY_SERVER_ADDRESS,
+            VALID_SESSION_ID,
+            { age: 23 },
+            null,
+            onSuccess,
+            onError,
+          ),
+        ).toEqual({ error: IdentifySessionError.noCollection })
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(onError).toHaveBeenCalledWith(404, IdentifySessionError.noCollection)
+      })
+
+      it('with invalidField error if the trait value has invalid format', async () => {
+        expect(
+          await sendSessionTraits(
+            VALID_AUTH_KEY,
+            GRAVITY_SERVER_ADDRESS,
+            VALID_SESSION_ID,
+            { tooLong: 'a'.repeat(256) },
+            null,
+            onSuccess,
+            onError,
+          ),
+        ).toEqual({ error: IdentifySessionError.invalidField })
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(onError).toHaveBeenCalledWith(422, IdentifySessionError.invalidField)
+      })
+
+      it('with incorrectSource error if source is not allowed', async () => {
+        expect(
+          await sendSessionTraits(
+            VALID_AUTH_KEY,
+            GRAVITY_SERVER_ADDRESS,
+            VALID_SESSION_ID,
+            { age: 23 },
+            'https://polop.com',
+            onSuccess,
+            onError,
+          ),
+        ).toEqual({ error: IdentifySessionError.incorrectSource })
+        expect(onSuccess).not.toHaveBeenCalled()
+        expect(onError).toHaveBeenCalledWith(403, IdentifySessionError.incorrectSource)
+      })
+    })
   })
 })
+
+function mockFetch() {
+  return vi.fn().mockImplementation(() => ({
+    json: async (): Promise<any> => await Promise.resolve({}),
+  }))
+}

--- a/src/test-utils/isUUID.ts
+++ b/src/test-utils/isUUID.ts
@@ -1,0 +1,4 @@
+export function isUUID(id: string): boolean {
+  const exp = /^[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$/
+  return exp.test(id)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,4 +98,6 @@ export interface CollectorOptions {
   onPublish?: (userActions: SessionUserAction[]) => void
 }
 
-export type TraitValue = string | number | boolean
+export type SessionTraits = Record<string, SessionTraitValue>
+
+export type SessionTraitValue = string | number | boolean

--- a/src/utils/listeners.ts
+++ b/src/utils/listeners.ts
@@ -5,7 +5,7 @@ const INPUT_ALLOWED_BY_KEY_LISTENERS = ['radio', 'select', 'checkbox', 'button']
 const KEYS_ALLOWED_BY_KEY_LISTENERS = ['tab', 'enter', 'numpadenter']
 
 export function isKeyAllowedByKeyListeners(keyCode: string): boolean {
-  return KEYS_ALLOWED_BY_KEY_LISTENERS.includes(keyCode.toLowerCase())
+  return keyCode !== undefined && KEYS_ALLOWED_BY_KEY_LISTENERS.includes(keyCode.toLowerCase())
 }
 
 export function isTargetAllowedByKeyListeners(target: EventTarget | null): boolean {


### PR DESCRIPTION
### Changed

- Type `Traits` renamed more precisely to `SessionTraits` and moved to `types.ts` file
- Type `TraitValue` renamed more precisely to `SessionTraitValue`
- Method `sendSessionTraits` now returns a response typed `IdentifySessionResponse` with well-typed error

### Fixed
- Prevent error in method `isKeyAllowedByKeyListeners`